### PR TITLE
feat(lodash): add plugin and rule to control import syntax for lodash

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,14 +5,16 @@ module.exports = {
     "./rules/base",
     "./rules/import",
     "./rules/jsx-ally",
+    "./rules/lodash",
     "./rules/react",
     "eslint-config-prettier",
-    "eslint-config-prettier/react",
+    "eslint-config-prettier/react"
   ].map(require.resolve),
   plugins: [
     "eslint-plugin-import",
     "eslint-plugin-jsx-a11y",
+    "eslint-plugin-lodash",
     "eslint-plugin-react"
   ],
   rules: {}
-}
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -624,6 +624,14 @@
         }
       }
     },
+    "eslint-plugin-lodash": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-lodash/-/eslint-plugin-lodash-6.0.0.tgz",
+      "integrity": "sha512-iuxToisjIYAJdxWtW8OamFyc3yAsGCjU5WokvuBfTc/k5XdWOp9fAmzw+aFjj520/QXspCc8//xJpqkhYUj4qw==",
+      "requires": {
+        "lodash": "^4.17.15"
+      }
+    },
     "eslint-plugin-react": {
       "version": "7.12.4",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-config-prettier": "^4.1.0",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-jsx-a11y": "^6.2.1",
+    "eslint-plugin-lodash": "^6.0.0",
     "eslint-plugin-react": "^7.12.4"
   },
   "engines": {

--- a/rules/lodash.js
+++ b/rules/lodash.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: ["lodash"],
+  rules: {
+    "lodash/import-scope": ["error", "method"]
+  }
+};


### PR DESCRIPTION
As suggested by @ejoubaud [here](https://github.com/jobteaser/jobteaser/pull/14079#issuecomment-561731767), this PR adds an eslint plugin to control the syntax used to import lodash function (https://github.com/wix/eslint-plugin-lodash/blob/master/docs/rules/import-scope.md).

## But why?

When using "global" import (`import { find } from "lodash"`) the entirety of lodash will be present in the final JS bundle.
But when using specific imports (`import find from "lodash/find"`), only the function imported (and its dependencies) will be present in the final bundle.

For more details, see https://github.com/jobteaser/jobteaser/pull/14079 .