### PR TITLE
chore(shared): Add react-hooks eslint

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports = {
     "./rules/jsx-ally",
     "./rules/lodash",
     "./rules/react",
+    "./rules/react-hooks",
     "eslint-config-prettier",
     "eslint-config-prettier/react"
   ].map(require.resolve),
@@ -14,7 +15,8 @@ module.exports = {
     "eslint-plugin-import",
     "eslint-plugin-jsx-a11y",
     "eslint-plugin-lodash",
-    "eslint-plugin-react"
+    "eslint-plugin-react",
+    "eslint-plugin-react-hooks"
   ],
   rules: {}
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -677,6 +677,11 @@
         }
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.4.tgz",
+      "integrity": "sha512-equAdEIsUETLFNCmmCkiCGq6rkSK5MoJhXFPFYeUebcjKgBmWWcgVOqZyQC8Bv1BwVCnTq9tBxgJFgAJTWoJtA=="
+    },
     "eslint-restricted-globals": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-lodash": "^6.0.0",
-    "eslint-plugin-react": "^7.12.4"
+    "eslint-plugin-react": "^7.12.4",
+    "eslint-plugin-react-hooks": "^4.0.4"
   },
   "engines": {
     "node": ">= 4"

--- a/rules/react-hooks.js
+++ b/rules/react-hooks.js
@@ -1,0 +1,9 @@
+module.exports = {
+  plugins: [
+    "react-hooks"
+  ],
+  rules: {
+    "react-hooks/rules-of-hooks": ["error"],
+    "react-hooks/exhaustive-deps": ["error"],
+  }
+}


### PR DESCRIPTION
Add react-hooks eslint in mode error

I already tested it in jobteaser monolith project. If you want to test it by yourself you just have to change this dependency line in jobteaser monolith package.json.

```
"eslint-config-jobteaser": "jobteaser/eslint-config-jobteaser#8d129971269aa2f76c706321a769e0a8413ae8db",
```