### PR TITLE
chore(shared): Put in mode warning some rules

### DIFF
--- a/rules/import.js
+++ b/rules/import.js
@@ -3,9 +3,9 @@ module.exports = {
     "import/extensions": ["off"],
     "import/first": ["warn"],
     "import/named": ["error"],
-    "import/no-default-export": ["error"],
+    "import/no-default-export": ["warn"],
     "import/no-extraneous-dependencies": ["off"],
-    "import/no-relative-parent-imports": ["error"],
+    "import/no-relative-parent-imports": ["warn"],
     "import/no-unresolved": ["off"],
     "import/prefer-default-export": ["off"],
   }

--- a/rules/react.js
+++ b/rules/react.js
@@ -50,5 +50,6 @@ module.exports = {
     "react/prefer-stateless-function": ["off"],
     "react/destructuring-assignment": ["error"],
     "react/no-access-state-in-setstate": ["off"],
+    "react/no-deprecated": ["warn"],
   }
 }


### PR DESCRIPTION
After merging react-hooks eslint we realized we have been updating this repo with error-mode rules but we didn't update the dependency version in monolith repo, so we had a lot of errors of 3 rules. We decided to put these three rules in mode warning.

![image](https://user-images.githubusercontent.com/7622399/85259183-de748c80-b468-11ea-9b96-a32b6fff0196.png)
