### PR TITLE
chore: disable operator assignment

### DIFF
--- a/rules/base.js
+++ b/rules/base.js
@@ -66,6 +66,7 @@ module.exports = {
     "no-var": ["error"],
     "object-curly-spacing": ["error", "always"],
     "one-var": ["error", "never"],
+    "operator-assignment": ["off"],
     "prefer-const": ["error"],
     "quotes": ["error", "double"],
 


### PR DESCRIPTION
Delete [operator-assignment](https://eslint.org/docs/rules/operator-assignment) rule as it has been decided in poll https://jobteaser.slack.com/archives/G01Q7QA4U3Z/p1631112688009700