### PR TITLE
chore(rules): add 'to' for id-length exceptions

### DIFF
--- a/rules/base.js
+++ b/rules/base.js
@@ -20,7 +20,7 @@ module.exports = {
     "id-length": ["error",
       {
         "min": 3,
-        "exceptions": ["e", "id", "cx"]
+        "exceptions": ["e", "id", "cx", "to"]
       }
     ],
     "max-len": ["warn",


### PR DESCRIPTION
## Description
This PR adds `to` to the exceptions of the `id-length` rule.
This is added since the Button and Link components allow a `to` props to create links with React-Router.