### PR TITLE
chore(global): update react/function-component-definition rule

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -14,7 +14,11 @@ module.exports = {
   },
   rules: {
     "react/forbid-prop-types": ["error"],
-    "react/function-component-definition": ["warn"],
+    "react/function-component-definition": ["warn",
+      {
+        "namedComponents": "arrow-function"
+      }
+    ],
     "react/jsx-closing-bracket-location": ["error", "tag-aligned"],
     "react/jsx-curly-brace-presence": ["warn"],
     "react/jsx-curly-spacing": ["error", "never"],


### PR DESCRIPTION
## Description

Update this rule [`react/function-component-definition`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/function-component-definition.md) to still to write the react component function like

```jsx
const Component = (props) => {
  return <div />;
};
```

## Jira ticket

https://jobteaser.atlassian.net/browse/OP-2062

## Related PR

- https://github.com/jobteaser/ui-jobteaser/pull/2059