### PR TITLE
chore(global): update testing-library/no-await-sync-events rule

### DIFF
--- a/rules/testing-library.js
+++ b/rules/testing-library.js
@@ -5,7 +5,12 @@ module.exports = {
     "testing-library/await-async-utils": "warn",
     "testing-library/await-fire-event": "warn",
     "testing-library/consistent-data-testid": "off",
-    "testing-library/no-await-sync-events": "warn",
+    "testing-library/no-await-sync-events": [
+      "warn",
+      {
+        eventModules: ["fire-event"],
+      },
+    ],
     "testing-library/no-await-sync-query": "error",
     "testing-library/no-container": "warn",
     "testing-library/no-debugging-utils": "error",
@@ -27,6 +32,6 @@ module.exports = {
     "testing-library/prefer-screen-queries": "warn",
     "testing-library/prefer-user-event": "warn",
     "testing-library/prefer-wait-for": "warn",
-    "testing-library/render-result-naming-convention": "warn"
+    "testing-library/render-result-naming-convention": "warn",
   },
 };


### PR DESCRIPTION
## Description

The rule "testing-library/no-await-sync-events" reports false positives for @testing-library/user-event v14 (see https://github.com/testing-library/eslint-plugin-testing-library/issues/567).

It causes many unwanted warnings in this PR: https://github.com/jobteaser/ui-jobteaser/pull/2140.

This PR fixes it with the official solution: https://github.com/testing-library/eslint-plugin-testing-library/blob/main/docs/rules/no-await-sync-events.md#notes.